### PR TITLE
NXP-21212 Enable to access a document bound to a forbidden template

### DIFF
--- a/nuxeo-template-rendering-core/src/main/java/org/nuxeo/template/adapters/doc/TemplateBasedDocumentAdapterImpl.java
+++ b/nuxeo-template-rendering-core/src/main/java/org/nuxeo/template/adapters/doc/TemplateBasedDocumentAdapterImpl.java
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Nuxeo - initial API and implementation
+ *     Estelle Giuly <egiuly@nuxeo.com>
  *
  */
 package org.nuxeo.template.adapters.doc;
@@ -33,6 +34,7 @@ import org.nuxeo.ecm.automation.core.operations.blob.ConvertBlob;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentRef;
+import org.nuxeo.ecm.core.api.DocumentSecurityException;
 import org.nuxeo.ecm.core.api.IdRef;
 import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.api.blobholder.BlobHolder;
@@ -139,13 +141,20 @@ public class TemplateBasedDocumentAdapterImpl extends AbstractTemplateDocument i
         if (tRef == null) {
             return null;
         }
-        return getSession().getDocument(tRef);
+        try {
+            return getSession().getDocument(tRef);
+        } catch (DocumentSecurityException e) {
+            return null;
+        }
     }
 
     public List<TemplateSourceDocument> getSourceTemplates() {
         List<TemplateSourceDocument> result = new ArrayList<TemplateSourceDocument>();
         for (TemplateBinding binding : bindings) {
-            result.add(getSourceTemplate(binding.getName()));
+            TemplateSourceDocument template = getSourceTemplate(binding.getName());
+            if (template != null) {
+                result.add(template);
+            }
         }
         return result;
     }
@@ -214,7 +223,11 @@ public class TemplateBasedDocumentAdapterImpl extends AbstractTemplateDocument i
             } catch (IOException e) {
                 throw new NuxeoException("Failed to render template: " + templateName, e);
             }
-            String format = getSourceTemplate(templateName).getOutputFormat();
+            TemplateSourceDocument template = getSourceTemplate(templateName);
+            if (template == null) {
+                throw new NuxeoException("No associated template for name " + templateName);
+            }
+            String format = template.getOutputFormat();
             if (blob != null && format != null && !format.isEmpty()) {
                 try {
                     return convertBlob(templateName, blob, format);
@@ -361,7 +374,8 @@ public class TemplateBasedDocumentAdapterImpl extends AbstractTemplateDocument i
 
     public String getTemplateNameForRendition(String renditionName) {
         for (TemplateBinding binding : bindings) {
-            if (renditionName.equals(getSourceTemplate(binding.getName()).getTargetRenditionName())) {
+            TemplateSourceDocument template = getSourceTemplate(binding.getName());
+            if (template != null && renditionName.equals(template.getTargetRenditionName())) {
                 return binding.getName();
             }
         }

--- a/nuxeo-template-rendering-core/src/main/java/org/nuxeo/template/rendition/TemplateBasedRenditionProvider.java
+++ b/nuxeo-template-rendering-core/src/main/java/org/nuxeo/template/rendition/TemplateBasedRenditionProvider.java
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Thierry Delprat
+ *     Estelle Giuly <egiuly@nuxeo.com>
  */
 package org.nuxeo.template.rendition;
 
@@ -48,9 +49,11 @@ public class TemplateBasedRenditionProvider implements RenditionProvider {
     public List<Blob> render(DocumentModel doc, RenditionDefinition definition) {
         TemplateBasedDocument tbd = doc.getAdapter(TemplateBasedDocument.class);
         String template = tbd.getTemplateNameForRendition(definition.getName());
-        Blob rendered = tbd.renderWithTemplate(template);
         List<Blob> blobs = new ArrayList<Blob>();
-        blobs.add(rendered);
+        if (template != null) {
+            Blob rendered = tbd.renderWithTemplate(template);
+            blobs.add(rendered);
+        }
         return blobs;
     }
 


### PR DESCRIPTION
JIRA: https://jira.nuxeo.com/browse/NXP-21212
Test&Push succeeded

**Description:**

A document X is bound to a template document T.
(For instance a Note is bound to the NoteWrapper template)
Joe has permission for the document X.
Joe doesn't have permission for the template document T.

The bug was that Joe couldn't open the document X (Exception thrown, error page).

In this PR, I make sure that Joe can open the document X:
- When trying to open the document X and looking for its bound templates to render it, 
the DocumentSecurityException thrown for the template T is now caught, and the template T is considered as not available.
- I added a unit test using ACP.